### PR TITLE
Support XDG_CONFIG_HOME and ZDOTDIR

### DIFF
--- a/quickalias.py
+++ b/quickalias.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 # Getting the home directory of the user.
-user_directory: str = os.environ['HOME']
+user_directory: str = os.path.expanduser('~')
 
 # Getting the process id of the parent process.
 process_id: str = os.readlink(f'/proc/{os.getppid()}/exe')

--- a/quickalias.py
+++ b/quickalias.py
@@ -26,7 +26,9 @@ elif "fish" in process_id:
     SHELL = "fish"
     # Getting the path of the config.fish file.
     shell_config_path: str = os.path.join(
-        user_directory, '.config/fish/config.fish')
+        os.environ.get('XDG_CONFIG_HOME') or
+        os.path.join(user_directory, '.config'),
+        'fish/config.fish')
 else:
     # If the shell is not detected, it will default to fish.
     SHELL = "fish"

--- a/quickalias.py
+++ b/quickalias.py
@@ -13,13 +13,15 @@ process_id: str = os.readlink(f'/proc/{os.getppid()}/exe')
 
 if "bash" in process_id:
     SHELL = "bash"
-    # Getting the path of the bashrc.
+    # Getting the path of the .bashrc file.
     shell_config_path: str = os.path.join(user_directory, '.bashrc')
 
 elif "zsh" in process_id:
     SHELL = "zsh"
    # Getting the path of the .zshrc file.
-    shell_config_path: str = os.path.join(user_directory, '.zshrc')
+    shell_config_path: str = os.path.join(
+        os.environ.get('ZDOTDIR') or user_directory,
+        '.zshrc')
 elif "fish" in process_id:
     SHELL = "fish"
     # Getting the path of the config.fish file.

--- a/quickalias.py
+++ b/quickalias.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 # Getting the home directory of the user.
-user_directory: str = os.path.expanduser('~')
+user_directory: str = os.environ['HOME']
 
 # Getting the process id of the parent process.
 process_id: str = os.readlink(f'/proc/{os.getppid()}/exe')


### PR DESCRIPTION
This should get the correct config file even If a user has their config file in a different location.

I don't know if using `os.environ['HOME']` has any disadvantages and `os.path.expanduser('~')` works fine so I reverted that commit.