### PR TITLE
Add optional positional arguments for alias and command

### DIFF
--- a/quickalias.py
+++ b/quickalias.py
@@ -18,8 +18,10 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=module_description)
     parser.add_argument(
         "-a", "--alias", help="the alias for the command", required=False)
+    parser.add_argument('alias', nargs='?',default=argparse.SUPPRESS)
     parser.add_argument("-c", "--command",
                         help="the command to be aliased", required=False)
+    parser.add_argument('command', nargs='?',default=argparse.SUPPRESS)
     args = parser.parse_args()
 
 


### PR DESCRIPTION
It would be practical to be able to do
`quickalias alias command`.
So i'd like to add optional positional arguments for this to work.
The keyword arguments still work so it would be possible to do:
`quickalias alias command`
`quickalias -a alias -c command` or
`quickalias`.